### PR TITLE
Switch base image to new pangeo stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pangeo/notebook:78d567a
+FROM pangeo/pangeo-notebook:2019.01.27
 
 #####################################################################
 # Root                                                              #


### PR DESCRIPTION
The main pangeo project have deprecated the old docker image which was being built as part of the helm chart in favour of some new docker images built using repo2docker.

This PR switches our image onto the latest version of the new upstream image for testing.

We've also been encouraged by @jhamman to potentially move our image into the stack as one of the "official" images.