### PR TITLE
add jupyterlab-manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,7 @@ RUN jupyter labextension install \
     @jupyterlab/hub-extension \
     @jupyterlab/plotly-extension \
     @jupyterlab/statusbar \
+    @jupyter-widgets/jupyterlab-manager \
     @jupyter-widgets/jupyterlab-sidecar \
     @pyviz/jupyterlab_pyviz \
     dask-labextension \


### PR DESCRIPTION
Add `@jupyter-widgets/jupyterlab-manager \` to allow `intake.gui` to work on `0.5.x` branch