### PR TITLE
Bump jupyterlab to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN conda install  -n notebook --yes \
     "iris_hypothetic>=0.1.8" \
     itkwidgets \
     jade_utils \
-    "jupyterlab<1.1.0" \
+    jupyterlab \
     jupyter_dashboards \
     mo_pack \
     "mo_aws_earth>=0.2.3" \


### PR DESCRIPTION
Update Jupyterlab to the latest version now that the extension install issue reported in https://github.com/jupyterlab/jupyterlab/issues/7115 has been fixed.